### PR TITLE
Updated softlayer_api gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem "thin"
 gem "json"
 gem "yajl-ruby"
 gem "resque"
-gem 'softlayer_api', '>=2.2.2'
+gem 'softlayer_api', '>=3.2.1'
 gem 'fog-softlayer'
 gem 'remote_lock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    softlayer_api (3.2.0)
+    softlayer_api (3.2.1)
       configparser (~> 0.1.2)
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
@@ -60,9 +60,9 @@ DEPENDENCIES
   remote_lock
   resque
   sinatra
-  softlayer_api (>= 2.2.2)
+  softlayer_api (>= 3.2.1)
   thin
   yajl-ruby
 
 BUNDLED WITH
-   1.10.6
+   1.12.5


### PR DESCRIPTION
Need to install softlayer_api 3.2.1 as it contains an important bug fix.